### PR TITLE
Feat/#19/주문-관리

### DIFF
--- a/src/components/mypage/tickets/PurchaseTicketBox.tsx
+++ b/src/components/mypage/tickets/PurchaseTicketBox.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { useQueryClient } from 'react-query';
 import { commaizeNumber } from '@toss/utils';
 
 import { Badge } from '@components/ui/badge';
@@ -9,13 +10,17 @@ import { PurchaseTicketType } from '@/types/ticket';
 import formatSingleTimestamp from '@utils/formatSingleTimestamp';
 import { useGlobalAlertStore } from '@store/useGlobalAlertStore';
 import { canclePurchase } from '@services/paymentService';
+import useUser from '@hooks/useUser';
 
 interface PurchaseTicketBoxProps {
   event: PurchaseTicketType;
+  page: number;
 }
 
-function PurchaseTicketBox({ event }: PurchaseTicketBoxProps) {
+function PurchaseTicketBox({ event, page }: PurchaseTicketBoxProps) {
+  const queryClient = useQueryClient();
   const { openAlert } = useGlobalAlertStore();
+  const user = useUser();
 
   const handleCancel = () => {
     try {
@@ -23,6 +28,7 @@ function PurchaseTicketBox({ event }: PurchaseTicketBoxProps) {
         .then(result => {
           if (result.success) {
             openAlert('취소가 완료되었습니다.', '');
+            queryClient.invalidateQueries(['tickets', user?.uid, page]);
           } else {
             openAlert('오류가 발생했습니다.', result.error as string);
           }

--- a/src/components/mypage/tickets/PurchaseTicketList.tsx
+++ b/src/components/mypage/tickets/PurchaseTicketList.tsx
@@ -41,7 +41,7 @@ function PurchaseTicketList({
     <div>
       <div className='mb-24 flex flex-col gap-6'>
         {events.map((event: PurchaseTicketType) => (
-          <PurchaseTicketBox key={event.id} event={event} />
+          <PurchaseTicketBox key={event.id} event={event} page={page} />
         ))}
       </div>
 

--- a/src/components/payment/PaymentReady.tsx
+++ b/src/components/payment/PaymentReady.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useMemo, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { commaizeNumber } from '@toss/utils';
@@ -20,6 +21,7 @@ interface PaymentReadyProps {
 }
 
 function PaymentReady({ setStep, state }: PaymentReadyProps) {
+  const queryClient = useQueryClient();
   const user = useUser();
   const { openAlert } = useGlobalAlertStore();
   const { removeFromCart } = useCartStore();
@@ -68,6 +70,7 @@ function PaymentReady({ setStep, state }: PaymentReadyProps) {
       .then(result => {
         if (result.success) {
           setStep(prev => prev + 1);
+          queryClient.invalidateQueries(['tickets', user?.uid, 0]);
 
           state.forEach(ticket => {
             removeFromCart(ticket.ticketId);


### PR DESCRIPTION
## 개요 :mag:

`주문 관리 수정`

## 작업사항 :memo:

#19 주문 관리
- 구매 성공/취소 시 useQuery 무효화 시키는 코드 추가
- 티켓 취소 시 해당 티켓의 재고 수량도 수정하게 수정

다음부터는 끝난 이슈에서 이어서 하지 말고 새로 이슈 파서 수정할게욥......
